### PR TITLE
KernelDotProduct to KernelLinear, Locked KernelParameters names

### DIFF
--- a/docs/notebooks/KernelUsage.ipynb
+++ b/docs/notebooks/KernelUsage.ipynb
@@ -26,7 +26,7 @@
     "When the user wants to try different kernels, it is pretty simple to do. The user can chose any class inherithing from the abstract `Kernel` (in the *Kernel Module*) and use it for spatial or temporal points. Some notable kernels that we can find in the *Kernel Module* are:\n",
     "\n",
     "* `KernelWhiteNoise`\n",
-    "* `KernelDotProduct`\n",
+    "* `KernelLinear`\n",
     "* `KernelSE`\n",
     "* `KernelRQ`\n",
     "* `KernelPeriodic`\n",


### PR DESCRIPTION
- Changed name of `KernelDotProduct` to `KernelLinear`
- Locked `KernelParameter` name and make it be set on set_kernel method. So it is not needed on initialization.